### PR TITLE
Do Not Auto-Focus Linux Debugger Output Window

### DIFF
--- a/src/VsLinuxDebugger/Commands.Impl.cs
+++ b/src/VsLinuxDebugger/Commands.Impl.cs
@@ -159,6 +159,7 @@ namespace VsLinuxDebugger
         HostPort = Settings.HostPort,
 
         LocalPLinkPath = Settings.LocalPLinkPath,
+        LocalSwitchLinuxDbgOutput = Settings.LocalSwitchLinuxDbgOutput,
 
         RemoteDebugDisplayGui = Settings.RemoteDebugDisplayGui,
         RemoteDeployBasePath = Settings.RemoteDeployBasePath,

--- a/src/VsLinuxDebugger/Core/SshTool.cs
+++ b/src/VsLinuxDebugger/Core/SshTool.cs
@@ -277,7 +277,7 @@ namespace VsLinuxDebugger.Core
     {
       try
       {
-        // Clean output folder just incase
+        // Clean output folder just in case
         //// Bash($@"rm -rf {_launch.RemoteDeployFolder}");
 
         // TODO: Rev1 - Iterate through each file and upload it via SCP client or SFTP.
@@ -296,6 +296,7 @@ namespace VsLinuxDebugger.Core
         Logger.Output($"Destination Tar.GZ: '{destTarGz}'");
 
         var success = await PayloadCompressAndUploadAsync(_sftp, srcDirInfo, destTarGz);
+        Logger.Output($"Upload completed {(success ? "successfully." : "with failure.")}.");
 
         // Decompress file
         await PayloadDecompressAsync(destTarGz, false);

--- a/src/VsLinuxDebugger/Core/UserOptions.cs
+++ b/src/VsLinuxDebugger/Core/UserOptions.cs
@@ -9,6 +9,7 @@
 
     public bool LocalPlinkEnabled { get; set; }
     public string LocalPLinkPath { get; set; }
+    public bool LocalSwitchLinuxDbgOutput { get; set; }
 
     public bool RemoteDebugDisplayGui { get; set; }
     public string RemoteDeployBasePath { get; set; }

--- a/src/VsLinuxDebugger/DebuggerPackage.cs
+++ b/src/VsLinuxDebugger/DebuggerPackage.cs
@@ -37,7 +37,14 @@ namespace VsLinuxDebugger
     public int HostPort => _optionsPage.HostPort;
 
     public string LocalPLinkPath => _optionsPage.PLinkPath;
-    public bool LocalSwitchLinuxDbgOutput => _optionsPage.SwitchLinuxDbgOutput;
+    public bool LocalSwitchLinuxDbgOutput
+    {
+      get
+      {
+        Logger.AutoSwitchToLinuxDbgOutput = _optionsPage.SwitchLinuxDbgOutput;
+        return _optionsPage.SwitchLinuxDbgOutput;
+      }
+    }
 
     public bool RemoteDebugDisplayGui => _optionsPage.RemoteDebugDisplayGui;
     public string RemoteDeployBasePath => _optionsPage.RemoteDeployBasePath;

--- a/src/VsLinuxDebugger/DebuggerPackage.cs
+++ b/src/VsLinuxDebugger/DebuggerPackage.cs
@@ -37,6 +37,7 @@ namespace VsLinuxDebugger
     public int HostPort => _optionsPage.HostPort;
 
     public string LocalPLinkPath => _optionsPage.PLinkPath;
+    public bool LocalSwitchLinuxDbgOutput => _optionsPage.SwitchLinuxDbgOutput;
 
     public bool RemoteDebugDisplayGui => _optionsPage.RemoteDebugDisplayGui;
     public string RemoteDeployBasePath => _optionsPage.RemoteDeployBasePath;
@@ -71,7 +72,7 @@ namespace VsLinuxDebugger
       await this.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
       await Commands.InitializeAsync(this);
 
-      Logger.Init(this, OutputWindowType.Custom);
+      Logger.Init(this, OutputWindowType.Custom, LocalSwitchLinuxDbgOutput);
       Logger.Output("InitializeAsync");
     }
 

--- a/src/VsLinuxDebugger/Logger.cs
+++ b/src/VsLinuxDebugger/Logger.cs
@@ -17,7 +17,6 @@ namespace VsLinuxDebugger
     private static string _name;
     private static IVsOutputWindowPane _outputPane;
     private static OutputWindowType _outputType = OutputWindowType.Debug;
-    private static bool _autoSwitchToLinuxDbgOutput;
     private static IServiceProvider _provider;
 
     private static string FormattedTime
@@ -33,6 +32,11 @@ namespace VsLinuxDebugger
       }
     }
 
+    /// <summary>
+    /// Automatically switch Visual Studio Output Window to 'Linux Debugger'.
+    /// </summary>
+    public static bool AutoSwitchToLinuxDbgOutput { get; set; }
+
     public static void Init(
       IServiceProvider provider,
       OutputWindowType outputType = OutputWindowType.Debug,
@@ -41,7 +45,7 @@ namespace VsLinuxDebugger
     {
       _provider = provider;
       _outputType = outputType;
-      _autoSwitchToLinuxDbgOutput = autoSwitchToLinuxDbgOutput;
+      AutoSwitchToLinuxDbgOutput = autoSwitchToLinuxDbgOutput;
       _name = name;
     }
 
@@ -65,7 +69,7 @@ namespace VsLinuxDebugger
           _outputPane.OutputStringThreadSafe(msg);
 
           // Brings pane into view
-          if (_autoSwitchToLinuxDbgOutput)
+          if (AutoSwitchToLinuxDbgOutput)
             _outputPane.Activate();
         }
       }

--- a/src/VsLinuxDebugger/Logger.cs
+++ b/src/VsLinuxDebugger/Logger.cs
@@ -17,6 +17,7 @@ namespace VsLinuxDebugger
     private static string _name;
     private static IVsOutputWindowPane _outputPane;
     private static OutputWindowType _outputType = OutputWindowType.Debug;
+    private static bool _autoSwitchToLinuxDbgOutput;
     private static IServiceProvider _provider;
 
     private static string FormattedTime
@@ -35,10 +36,12 @@ namespace VsLinuxDebugger
     public static void Init(
       IServiceProvider provider,
       OutputWindowType outputType = OutputWindowType.Debug,
+      bool autoSwitchToLinuxDbgOutput = true,
       string name = "Linux Debugger")
     {
       _provider = provider;
       _outputType = outputType;
+      _autoSwitchToLinuxDbgOutput = autoSwitchToLinuxDbgOutput;
       _name = name;
     }
 
@@ -60,7 +63,10 @@ namespace VsLinuxDebugger
         if (HasOutputWindow())
         {
           _outputPane.OutputStringThreadSafe(msg);
-          _outputPane.Activate(); // Brings pane into view
+
+          // Brings pane into view
+          if (_autoSwitchToLinuxDbgOutput)
+            _outputPane.Activate();
         }
       }
       catch (Exception)

--- a/src/VsLinuxDebugger/OptionsPages/OptionsPage.Local.cs
+++ b/src/VsLinuxDebugger/OptionsPages/OptionsPage.Local.cs
@@ -37,7 +37,7 @@ namespace Xeno.VsLinuxDebug.OptionsPages
 
     [Category(Local)]
     [DisplayName("Switch to LinuxDbg Output on Build")]
-    [Description("Automatically show output for Linux Debugger on build (default = true).")]
-    public bool SwitchLinuxDbgOutput { get; set; } = true;
+    [Description("Automatically show output for Linux Debugger on build (default = false).")]
+    public bool SwitchLinuxDbgOutput { get; set; } = false;
   }
 }

--- a/src/VsLinuxDebugger/OptionsPages/OptionsPage.Local.cs
+++ b/src/VsLinuxDebugger/OptionsPages/OptionsPage.Local.cs
@@ -34,5 +34,10 @@ namespace Xeno.VsLinuxDebug.OptionsPages
     [DisplayName("Delete 'launch.json' after build.")]
     [Description(@"The `launch.json` is generated in your build folder. You may keep this for debugging.")]
     public bool DeleteLaunchJsonAfterBuild { get; set; } = false;
+
+    [Category(Local)]
+    [DisplayName("Switch to LinuxDbg Output on Build")]
+    [Description("Automatically show output for Linux Debugger on build (default = true).")]
+    public bool SwitchLinuxDbgOutput { get; set; } = true;
   }
 }

--- a/src/VsLinuxDebugger/release-notes.md
+++ b/src/VsLinuxDebugger/release-notes.md
@@ -2,7 +2,7 @@
 
 ## 2.0.0-Alpha
 
-* Added: Option to set output window focus to Linux Debugger
+* Added: Option to set output window focus to Linux Debugger. Default, false.
 
 ## 1.9.0
 

--- a/src/VsLinuxDebugger/release-notes.md
+++ b/src/VsLinuxDebugger/release-notes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 2.0.0-Alpha
+
+* Added: Option to set output window focus to Linux Debugger
+
 ## 1.9.0
 
 * Added: Now comes with PLink embedded. You can still manually set this if you prefer.

--- a/updates.md
+++ b/updates.md
@@ -6,7 +6,7 @@ This document contains the release information for the project.
 
 ### 2.0.0-Alpha
 
-* Added: Option to set output window focus to Linux Debugger
+* Added: Option to set output window focus to Linux Debugger. Default, false.
 
 ### 1.9.0
 

--- a/updates.md
+++ b/updates.md
@@ -4,6 +4,10 @@ This document contains the release information for the project.
 
 ## Releases
 
+### 2.0.0-Alpha
+
+* Added: Option to set output window focus to Linux Debugger
+
 ### 1.9.0
 
 * Added: Now comes with PLink embedded. You can still manually set this if you prefer.


### PR DESCRIPTION
As per #42, do not automatically switch the Output window focus to "Linux Debugger".

## Feature Includes:
* System adds Option to "_Switch to LinuxDbg Output on Build_" - Default: **False**
