### PR TITLE
Version bump to v2.3.0 and release notes

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -4,7 +4,16 @@
 
 This document contains the release information for the project.
 
-### 2.2.0
+### 2.3.0 - 2024-12-02
+
+Early patch release before Christmas break. Effort moving forward will be for the upcoming 3.0 release.
+
+* Fixed: Fix connection error when using SSH private key (PR #95, Issue #82)
+* Added: Setting that allows to change the remote X11 display number (PR #94)
+* Update: Bump System.Text.Json from 6.0.2 to 6.0.10 (PR #92)
+* Update: Documentation (PR #91)
+
+### 2.2.0 - 2024-03-08
 
 * Fixed: Support VS v17.9 (#79)
 * Update: SSH.NET to v2023.0.1

--- a/src/VsLinuxDebugger/source.extension.vsixmanifest
+++ b/src/VsLinuxDebugger/source.extension.vsixmanifest
@@ -4,7 +4,7 @@
                  xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
         <Identity Id="VsLinuxDebugger.4d7bf4de-5015-4e24-92c0-7f9f3397b2da"
-                  Version="2.2.0"
+                  Version="2.3.0"
                   Language="en-US"
                   Publisher="Suess Labs" />
         <DisplayName>VS Linux Debugger</DisplayName>
@@ -14,7 +14,7 @@
         <GettingStartedGuide>..\..\readme.md</GettingStartedGuide>
         <ReleaseNotes>..\..\release-notes.md</ReleaseNotes>
         <Icon>Resources\TuxDebug.png</Icon>
-        <Tags>debug; build; remote debug; vsdbg; linux; xamarin; rpi; rpi4; remotedebug; remote; debugger; linux debug; net6; dotnet; raspberry pi; ubuntu; suess; suess-labs; xeno-innovations</Tags>
+        <Tags>debug; build; remote debug; vsdbg; linux; avalonia; xamarin; rpi; rpi4; remotedebug; remote; debugger; linux debug; net6; dotnet; raspberry pi; ubuntu; suess; suess-labs; suesslabs; xeno-innovations</Tags>
     </Metadata>
     <Installation>
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">


### PR DESCRIPTION
## Description of Change

Version bump to v2.3.0 and release notes.

## Notice

All new features will be scheduled for the 3.0. Only bug fixes and minor patches will be applied to the v2.x series. 

## Related Work Items

N/A
